### PR TITLE
Fix: Compatibility error for steel_ingot recipe

### DIFF
--- a/src/generated/resources/data/alloyed/recipes/mixing/steel_ingot.json
+++ b/src/generated/resources/data/alloyed/recipes/mixing/steel_ingot.json
@@ -20,7 +20,6 @@
       }
     ]
   ],
-  "processingTime": 200,
   "results": [
     {
       "count": 3,

--- a/src/main/java/com/molybdenum/alloyed/data/recipes/MixingRecipes.java
+++ b/src/main/java/com/molybdenum/alloyed/data/recipes/MixingRecipes.java
@@ -43,7 +43,6 @@ public class MixingRecipes extends ModProcessingRecipes {
             .require(Ingredient.of(Items.COAL, Items.CHARCOAL))
             .output(ModItems.STEEL_INGOT.get(), 3)
             .requiresHeat(HeatCondition.HEATED)
-            .duration(200)
     );
 
     public MixingRecipes(PackOutput output) {


### PR DESCRIPTION
# Subject
A processing time is set for the steel_ingot recipe using the mixer.

# Problem
Mixing recipes does not support setting processing time, setting it does not change the time it takes to process the recipe.
However, setting a processing time break compatibility with other mods changing or adding mixers like Create: Encased as they tweak processing time to work.

See: https://github.com/Creators-of-Create/Create/wiki/Custom-Recipes

# Solution
Removing the process time from the recipe.